### PR TITLE
Fix broken schedule when a boss is not killed & added auto release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,62 @@
+name: Auto Release
+
+on:
+  push:
+    branches: ["master"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build --configuration Release
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=<Version>)[^<]+' BloodyBoss.csproj)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" --repo ${{ github.repository }} >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            "bin/Release/net6.0/BloodyBoss.dll" \
+            --repo ${{ github.repository }} \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes "Automated release built from master."

--- a/BloodyBoss.csproj
+++ b/BloodyBoss.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyName>BloodyBoss</AssemblyName>
 		<Description>Advanced BloodyBoss mod for VRising with dynamic scaling, progressive difficulty, and phase announcements</Description>
-		<Version>2.1.4</Version>
+		<Version>2.1.5</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>

--- a/Configuration/PluginConfig.cs
+++ b/Configuration/PluginConfig.cs
@@ -24,6 +24,7 @@ namespace BloodyBoss.Configuration
         public static ConfigEntry<bool> BuffAfterKillingEnabled { get; private set; }
         public static ConfigEntry<int> BuffAfterKillingPrefabGUID { get; private set; }
         public static ConfigEntry<bool> TeamBossEnable { get; private set; }
+        public static ConfigEntry<int> StuckBossRecoveryTimeoutSeconds { get; private set; }
 
         // Dynamic Scaling Configuration
         public static ConfigEntry<bool> EnableDynamicScaling { get; private set; }
@@ -111,7 +112,7 @@ namespace BloodyBoss.Configuration
             BuffAfterKillingEnabled = _mainConfig.Bind("Main", "BuffAfterKillingEnabled", true, "Deactivates the buff animation received by players who have participated in the battle for three seconds.");
             BuffAfterKillingPrefabGUID = _mainConfig.Bind("Main", "BuffAfterKillingPrefabGUID", -2061047741, "PrefabGUID of the buff received by players who have participated in the battle for three seconds.");
             TeamBossEnable = _mainConfig.Bind("Main", "TeamBossEnable", false, "If you activate this option, the bosses will not attack each other and will team up if two bosses are summoned together..");
-
+            StuckBossRecoveryTimeoutSeconds = _mainConfig.Bind("Main", "StuckBossRecoveryTimeoutSeconds", 10, "Auto-finalizes a boss at 0 HP after this many seconds if no player kill is detected, keeping the schedule running. Set to 0 to disable.");
             // Dynamic Scaling Configuration
             EnableDynamicScaling = _mainConfig.Bind("Dynamic Scaling", "Enable", false, "Enable dynamic scaling based on online players");
             BaseHealthMultiplier = _mainConfig.Bind("Dynamic Scaling", "BaseHealthMultiplier", 1.0f, "Base health multiplier for all bosses");

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BloodyBoss v2.1.4
+# BloodyBoss v2.1.5
 
 **BloodyBoss** is an advanced mod for V Rising that allows you to create dynamic VBlood world bosses with intelligent scaling, progressive difficulty, and extensive customization options. Create epic encounters that adapt to your player base and provide engaging challenges for solo players and large groups alike.
 
@@ -414,4 +414,4 @@ If you enjoy BloodyBoss and want to support continued development:
 
 ---
 
-*BloodyBoss v2.1.4 - Creating legendary encounters for V Rising servers worldwide* 🧛‍♂️⚔️
+*BloodyBoss v2.1.5 - Creating legendary encounters for V Rising servers worldwide* 🧛‍♂️⚔️

--- a/Systems/BossTrackingSystem.cs
+++ b/Systems/BossTrackingSystem.cs
@@ -6,6 +6,7 @@ using Unity.Collections;
 using BloodyBoss.DB.Models;
 using BloodyBoss.DB;
 using BloodyBoss.Configuration;
+using BloodyBoss.Components;
 using Bloody.Core;
 using Bloody.Core.Patch.Server;
 using Bloody.Core.API.v1;
@@ -22,15 +23,15 @@ namespace BloodyBoss.Systems
     {
         // Active bosses indexed by entity for O(1) lookup
         private static readonly Dictionary<Entity, TrackedBoss> _activeBosses = new Dictionary<Entity, TrackedBoss>();
-        
+
         // Quick lookup by boss name for spawn/despawn operations
         private static readonly Dictionary<string, Entity> _bossesByName = new Dictionary<string, Entity>();
-        
+
         // Track last update time to avoid unnecessary checks
         private static DateTime _lastUpdateTime = DateTime.UtcNow;
-        
+
         // Last update time to batch operations
-        
+
         private class TrackedBoss
         {
             public Entity Entity { get; set; }
@@ -43,9 +44,12 @@ namespace BloodyBoss.Systems
             public bool WasEngaged { get; set; } = false;
             public bool NeedsTeamReferenceSync { get; set; } = false;
             public TeamReference? StoredTeamReference { get; set; } = null;
+
+            // Timestamp of when health first hit 0. Used by HandleBossDeath to force
+            // bossSpawn clear if the game never confirms the kill.
             public DateTime? DeathDetectedAt { get; set; } = null;
         }
-        
+
         /// <summary>
         /// Register a spawned boss for tracking
         /// </summary>
@@ -55,7 +59,7 @@ namespace BloodyBoss.Systems
             {
                 Plugin.BLogger.Debug(LogCategory.Boss, $"[BossTracking] Boss {model.name} already registered, updating");
             }
-            
+
             var tracked = new TrackedBoss
             {
                 Entity = entity,
@@ -63,15 +67,18 @@ namespace BloodyBoss.Systems
                 SpawnTime = DateTime.UtcNow,
                 NextDespawnCheck = DateTime.UtcNow.AddSeconds(5), // Check every 5 seconds
                 NextMechanicCheck = DateTime.UtcNow.AddSeconds(1), // Check mechanics every second
-                NeedsTeamCheck = true
+                NeedsTeamCheck = true,
+                // Seed at 100% so HealthMonitorSystem doesn't see a false 0→100 jump
+                // when it first observes this boss before ModifyBoss has run.
+                LastHealthPercent = 100f
             };
-            
+
             _activeBosses[entity] = tracked;
             _bossesByName[model.name] = entity;
-            
+
             Plugin.BLogger.Debug(LogCategory.Boss, $"[BossTracking] Registered boss {model.name} for optimized tracking. Active bosses: {_activeBosses.Count}");
         }
-        
+
         /// <summary>
         /// Unregister a boss (death/despawn)
         /// </summary>
@@ -81,10 +88,16 @@ namespace BloodyBoss.Systems
             {
                 _bossesByName.Remove(tracked.Model.name);
                 _activeBosses.Remove(entity);
+
+                // BUG FIX #13: BossComponentsHelper._bossStateCache was never cleared on despawn,
+                // causing it to grow indefinitely and hold stale references to destroyed entities.
+                // Clear the state entry here since UnregisterBoss is the canonical cleanup point.
+                BossComponentsHelper.RemoveBossState(entity);
+
                 Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Unregistered boss {tracked.Model.name}. Active bosses: {_activeBosses.Count}");
             }
         }
-        
+
         /// <summary>
         /// Get boss by name
         /// </summary>
@@ -92,9 +105,11 @@ namespace BloodyBoss.Systems
         {
             return _bossesByName.TryGetValue(name, out entity);
         }
-        
+
         /// <summary>
-        /// Optimized update - only check what needs checking
+        /// Only checks what needs checking, to avoid unnecessary work.
+        /// Schedules the update on the main thread via ActionScheduler.
+        /// Use this only if you're not already on the main thread.
         /// </summary>
         public static void UpdateActiveBosses()
         {
@@ -111,35 +126,52 @@ namespace BloodyBoss.Systems
                 }
             });
         }
-        
+
+        /// <summary>
+        /// Call this instead when already running on the main game thread
+        /// (e.g. from inside BossSystem.bossAction, which is already wrapped
+        /// in RunActionOnMainThread), to avoid scheduling a second one.
+        /// </summary>
+        public static void UpdateActiveBossesOnMainThread()
+        {
+            try
+            {
+                UpdateActiveBossesInternal();
+            }
+            catch (Exception ex)
+            {
+                Plugin.BLogger.Error(LogCategory.Boss, $"[BossTracking] Error in UpdateActiveBossesOnMainThread: {ex.Message}");
+            }
+        }
+
         private static void UpdateActiveBossesInternal()
         {
             var now = DateTime.UtcNow;
             var entitiesToRemove = new List<Entity>();
             var entityManager = Plugin.SystemsCore.EntityManager;
-            
+
             foreach (var kvp in _activeBosses)
             {
                 var entity = kvp.Key;
                 var tracked = kvp.Value;
-                
+
                 // Validate entity still exists
                 if (!entityManager.Exists(entity))
                 {
                     Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} entity no longer exists (despawned by LifeTime)");
-                    
+
                     // Clean up minions before removing boss
                     MinionTrackingSystem.OnBossDeathOrDespawn(entity);
-                    
+
                     entitiesToRemove.Add(entity);
-                    
+
                     // Perform cleanup since entity was despawned (not killed)
                     tracked.Model.bossSpawn = false;
                     tracked.Model.bossEntity = Entity.Null;
                     BossGameplayEventSystem.UnregisterBoss(entity);
                     BossMechanicSystem.CleanupBossMechanics(tracked.Model);
                     Database.saveDatabase();
-                    
+
                     // Send despawn message if configured
                     if (!string.IsNullOrEmpty(PluginConfig.DespawnMessageBossTemplate.Value))
                     {
@@ -148,10 +180,10 @@ namespace BloodyBoss.Systems
                         var fixedMessage = (FixedString512Bytes)FontColorChatSystem.Green($"{message}");
                         ServerChatUtils.SendSystemMessageToAllClients(Plugin.SystemsCore.EntityManager, ref fixedMessage);
                     }
-                    
+
                     continue;
                 }
-                
+
                 // Check if boss is dead or has regenerated
                 if (entity.Has<ProjectM.Health>())
                 {
@@ -165,6 +197,8 @@ namespace BloodyBoss.Systems
                         continue;
                     }
 
+                    // Health went back above 0 before the kill was confirmed, so clear
+                    // the pending death timer for next time.
                     if (tracked.DeathDetectedAt.HasValue)
                     {
                         tracked.DeathDetectedAt = null;
@@ -172,56 +206,55 @@ namespace BloodyBoss.Systems
 
                     // Calculate current health percentage
                     float currentHealthPercent = (health.Value / health.MaxHealth.Value) * 100f;
-                    
+
                     // Check if boss has regenerated back to full health after being engaged
                     if (tracked.WasEngaged && currentHealthPercent >= 99f && tracked.LastHealthPercent < 99f)
                     {
                         Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} regenerated to full health, resetting mechanics");
-                        
+
                         // Reset all mechanics
                         foreach (var mechanic in tracked.Model.Mechanics)
                         {
                             mechanic.Reset();
                         }
-                        
+
                         // Reset boss start time for time-based mechanics
                         var bossKey = $"{tracked.Model.nameHash}";
                         BossMechanicSystem.InitializeBossMechanics(entity, tracked.Model);
-                        
+
                         // Save the database to persist the reset
                         Database.saveDatabase();
-                        
+
                         // Reset tracking flags
                         tracked.WasEngaged = false;
                     }
-                    
+
                     // Mark as engaged if health drops below 95%
                     if (currentHealthPercent < 95f)
                     {
                         tracked.WasEngaged = true;
                     }
-                    
+
                     // Update last health percent
                     tracked.LastHealthPercent = currentHealthPercent;
                 }
-                
-                // Despawn check removed - now handled by EntityDestroyHook
-                // The LifeTime component will handle despawn automatically
-                // and our hook will detect it for cleanup
-                
+
+                // Despawn is handled by EntityDestroyHook now: the LifeTime
+                // component destroys the entity and our hook detects it for cleanup.
+
                 // Mechanic check (every second)
                 if (now >= tracked.NextMechanicCheck)
                 {
                     tracked.NextMechanicCheck = now.AddSeconds(1);
                     CheckMechanics(entity, tracked);
                 }
-                
+
                 // Team check (only once after spawn)
                 if (tracked.NeedsTeamCheck)
                 {
                     BossSystem.CheckTeams(entity);
                     tracked.NeedsTeamCheck = false;
-                    
+
                     // If this is the first boss, store its TeamReference when it's valid
                     if (Database.TeamDefault != null && Database.TeamReferenceDefault == null)
                     {
@@ -247,21 +280,21 @@ namespace BloodyBoss.Systems
                         tracked.StoredTeamReference = Database.TeamReferenceDefault;
                     }
                 }
-                
+
                 // TeamReference sync check (wait for valid TeamReference)
                 if (tracked.NeedsTeamReferenceSync)
                 {
                     if (entityManager.HasComponent<TeamReference>(entity))
                     {
                         var currentTeamRef = entityManager.GetComponentData<TeamReference>(entity);
-                        
+
                         // If this is the first boss and we're waiting for a valid TeamReference
                         if (Database.TeamReferenceDefault == null && currentTeamRef.Value._Value != Entity.Null)
                         {
                             Database.TeamReferenceDefault = currentTeamRef;
                             tracked.NeedsTeamReferenceSync = false;
                             Plugin.BLogger.Warning(LogCategory.Boss, $"[BossTracking] First boss now has valid TeamReference, storing it");
-                            
+
                             // Mark all other tracked bosses to sync
                             foreach (var otherBoss in _activeBosses.Values.Where(b => b != tracked))
                             {
@@ -279,29 +312,30 @@ namespace BloodyBoss.Systems
                     }
                 }
             }
-            
+
             // Remove invalid entities
             foreach (var entity in entitiesToRemove)
             {
                 UnregisterBoss(entity);
             }
-            
+
             // Update minion tracking
             MinionTrackingSystem.UpdateMinions();
         }
 
         /// <summary>
-        /// Called every tick while a tracked boss's health is at or below 0 gives the
-        /// game's own kill confirmation hooks (OnDeathNpc / OnVBloodConsumed in
-        /// BossGameplayEventSystem) time to fire and reset Model.bossSpawn normally 
-        /// those only fire when the death/consume is cleanly attributed to a player
+        /// Runs while a boss's health sits at 0, waiting for OnDeathNpc or
+        /// OnVBloodConsumed to confirm the kill and clear bossSpawn. If nothing
+        /// confirms it within the timeout, forces the same cleanup so the boss
+        /// doesn't stay "active" and block the schedule.
         /// </summary>
-        /// <returns>True once this boss is finalized and should be removed from tracking</returns>
+        /// <returns>True once the boss is finalized and should be removed from tracking.</returns>
         private static bool HandleBossDeath(Entity entity, TrackedBoss tracked, DateTime now)
         {
             if (tracked.DeathDetectedAt == null)
             {
                 tracked.DeathDetectedAt = now;
+                // Clean up minions right away, regardless of when the kill gets confirmed.
                 MinionTrackingSystem.OnBossDeathOrDespawn(entity);
                 Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} health reached 0, waiting for kill confirmation");
             }
@@ -309,12 +343,13 @@ namespace BloodyBoss.Systems
             var timeoutSeconds = PluginConfig.StuckBossRecoveryTimeoutSeconds.Value;
             if (timeoutSeconds > 0 && now - tracked.DeathDetectedAt.Value < TimeSpan.FromSeconds(timeoutSeconds))
             {
+                // Still within the grace period, keep waiting for a normal kill confirmation.
                 return false;
             }
 
             if (tracked.Model.bossSpawn)
             {
-                Plugin.BLogger.Warning(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} died but no kill was ever confirmed by the game forcing schedule recovery");
+                Plugin.BLogger.Warning(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} died without a confirmed kill, forcing recovery so the schedule doesn't get stuck");
 
                 try
                 {
@@ -324,7 +359,9 @@ namespace BloodyBoss.Systems
                 }
                 catch (Exception ex)
                 {
-                    Plugin.BLogger.Error(LogCategory.Boss, $"[BossTracking] Error killing stuck boss {tracked.Model.name}: {ex.Message}");
+                    Plugin.BLogger.Error(LogCategory.Boss, $"[BossTracking] Error force-finalizing stuck boss {tracked.Model.name}: {ex.Message}");
+                    // Fallback in case the cleanup above threw partway through, so
+                    // bossSpawn still gets cleared.
                     tracked.Model.bossSpawn = false;
                     tracked.Model.bossEntity = Entity.Null;
                     Database.saveDatabase();
@@ -341,7 +378,7 @@ namespace BloodyBoss.Systems
                 // Check time-based and player count mechanics
                 BossMechanicSystem.CheckTimeMechanics(entity, tracked.Model);
                 BossMechanicSystem.CheckPlayerCountMechanics(entity, tracked.Model);
-                
+
                 // REMOVED: ModifyBoss should only be called once during spawn, not repeatedly
                 // This was causing the boss to reset its health to 100% constantly
             }
@@ -350,7 +387,7 @@ namespace BloodyBoss.Systems
                 Plugin.BLogger.Error(LogCategory.Boss, $"[BossTracking] Error checking mechanics: {ex.Message}");
             }
         }
-        
+
         /// <summary>
         /// Get count of active bosses
         /// </summary>
@@ -358,7 +395,20 @@ namespace BloodyBoss.Systems
         {
             return _activeBosses.Count;
         }
-        
+
+        /// <summary>
+        /// Returns the last recorded health percentage for a tracked boss entity.
+        /// Used by BossGameplayEventSystem.ProcessStatChangeEvent to supply a correct
+        /// previousHpPercent to CheckHpThresholdMechanics instead of a hardcoded 100f.
+        /// Returns 100f if the entity isn't tracked (assumes full health).
+        /// </summary>
+        public static float GetLastHealthPercent(Entity entity)
+        {
+            if (_activeBosses.TryGetValue(entity, out var tracked))
+                return tracked.LastHealthPercent;
+            return 100f;
+        }
+
         /// <summary>
         /// Clear all tracked bosses
         /// </summary>

--- a/Systems/BossTrackingSystem.cs
+++ b/Systems/BossTrackingSystem.cs
@@ -65,8 +65,8 @@ namespace BloodyBoss.Systems
                 Entity = entity,
                 Model = model,
                 SpawnTime = DateTime.UtcNow,
-                NextDespawnCheck = DateTime.UtcNow.AddSeconds(5),
-                NextMechanicCheck = DateTime.UtcNow.AddSeconds(1),
+                NextDespawnCheck = DateTime.UtcNow.AddSeconds(5), // Check every 5 seconds
+                NextMechanicCheck = DateTime.UtcNow.AddSeconds(1), // Check mechanics every second
                 NeedsTeamCheck = true,
                 // Seed at 100% so HealthMonitorSystem doesn't see a false 0→100 jump
                 // when it first observes this boss before ModifyBoss has run.
@@ -107,9 +107,9 @@ namespace BloodyBoss.Systems
         }
 
         /// <summary>
-        /// Optimized update - only check what needs checking.
-        /// Schedules work on the main thread via ActionScheduler.
-        /// Use this only if you are NOT already on the main thread.
+        /// Only checks what needs checking, to avoid unnecessary work.
+        /// Schedules the update on the main thread via ActionScheduler.
+        /// Use this only if you're not already on the main thread.
         /// </summary>
         public static void UpdateActiveBosses()
         {
@@ -128,9 +128,9 @@ namespace BloodyBoss.Systems
         }
 
         /// <summary>
-        /// Direct update — call this when already running on the main game thread
-        /// (e.g. from inside BossSystem.bossAction which is wrapped in RunActionOnMainThread).
-        /// Avoids scheduling a second RunActionOnMainThread from within one.
+        /// Call this instead when already running on the main game thread
+        /// (e.g. from inside BossSystem.bossAction, which is already wrapped
+        /// in RunActionOnMainThread), to avoid scheduling a second one.
         /// </summary>
         public static void UpdateActiveBossesOnMainThread()
         {
@@ -197,6 +197,13 @@ namespace BloodyBoss.Systems
                         continue;
                     }
 
+                    // Health went back above 0 before the kill was confirmed, so clear
+                    // the pending death timer for next time.
+                    if (tracked.DeathDetectedAt.HasValue)
+                    {
+                        tracked.DeathDetectedAt = null;
+                    }
+
                     // Calculate current health percentage
                     float currentHealthPercent = (health.Value / health.MaxHealth.Value) * 100f;
 
@@ -232,9 +239,8 @@ namespace BloodyBoss.Systems
                     tracked.LastHealthPercent = currentHealthPercent;
                 }
 
-                // Despawn check removed - now handled by EntityDestroyHook
-                // The LifeTime component will handle despawn automatically
-                // and our hook will detect it for cleanup
+                // Despawn is handled by EntityDestroyHook now: the LifeTime
+                // component destroys the entity and our hook detects it for cleanup.
 
                 // Mechanic check (every second)
                 if (now >= tracked.NextMechanicCheck)
@@ -317,6 +323,53 @@ namespace BloodyBoss.Systems
             MinionTrackingSystem.UpdateMinions();
         }
 
+        /// <summary>
+        /// Runs while a boss's health sits at 0, waiting for OnDeathNpc or
+        /// OnVBloodConsumed to confirm the kill and clear bossSpawn. If nothing
+        /// confirms it within the timeout, forces the same cleanup so the boss
+        /// doesn't stay "active" and block the schedule.
+        /// </summary>
+        /// <returns>True once the boss is finalized and should be removed from tracking.</returns>
+        private static bool HandleBossDeath(Entity entity, TrackedBoss tracked, DateTime now)
+        {
+            if (tracked.DeathDetectedAt == null)
+            {
+                tracked.DeathDetectedAt = now;
+                // Clean up minions right away, regardless of when the kill gets confirmed.
+                MinionTrackingSystem.OnBossDeathOrDespawn(entity);
+                Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} health reached 0, waiting for kill confirmation");
+            }
+
+            var timeoutSeconds = PluginConfig.StuckBossRecoveryTimeoutSeconds.Value;
+            if (timeoutSeconds > 0 && now - tracked.DeathDetectedAt.Value < TimeSpan.FromSeconds(timeoutSeconds))
+            {
+                // Still within the grace period, keep waiting for a normal kill confirmation.
+                return false;
+            }
+
+            if (tracked.Model.bossSpawn)
+            {
+                Plugin.BLogger.Warning(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} died without a confirmed kill, forcing recovery so the schedule doesn't get stuck");
+
+                try
+                {
+                    BossGameplayEventSystem.UnregisterBoss(entity);
+                    tracked.Model.BuffKillers();
+                    tracked.Model.SendAnnouncementMessage();
+                }
+                catch (Exception ex)
+                {
+                    Plugin.BLogger.Error(LogCategory.Boss, $"[BossTracking] Error force-finalizing stuck boss {tracked.Model.name}: {ex.Message}");
+                    // Fallback in case the cleanup above threw partway through, so
+                    // bossSpawn still gets cleared.
+                    tracked.Model.bossSpawn = false;
+                    tracked.Model.bossEntity = Entity.Null;
+                    Database.saveDatabase();
+                }
+            }
+
+            return true;
+        }
 
         private static void CheckMechanics(Entity entity, TrackedBoss tracked)
         {
@@ -344,10 +397,10 @@ namespace BloodyBoss.Systems
         }
 
         /// <summary>
-        /// BUG FIX #11: Returns the last recorded health percentage for a tracked boss entity.
-        /// Used by BossGameplayEventSystem.ProcessStatChangeEvent to supply a correct previousHpPercent
-        /// to CheckHpThresholdMechanics, instead of always passing the hardcoded 100f default.
-        /// Returns 100f if the entity is not tracked (safe fallback — assumes full health).
+        /// Returns the last recorded health percentage for a tracked boss entity.
+        /// Used by BossGameplayEventSystem.ProcessStatChangeEvent to supply a correct
+        /// previousHpPercent to CheckHpThresholdMechanics instead of a hardcoded 100f.
+        /// Returns 100f if the entity isn't tracked (assumes full health).
         /// </summary>
         public static float GetLastHealthPercent(Entity entity)
         {

--- a/Systems/BossTrackingSystem.cs
+++ b/Systems/BossTrackingSystem.cs
@@ -303,7 +303,7 @@ namespace BloodyBoss.Systems
             {
                 tracked.DeathDetectedAt = now;
                 MinionTrackingSystem.OnBossDeathOrDespawn(entity);
-                Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} health reached 0, waiting for kill confwirmation");
+                Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} health reached 0, waiting for kill confirmation");
             }
 
             var timeoutSeconds = PluginConfig.StuckBossRecoveryTimeoutSeconds.Value;

--- a/Systems/BossTrackingSystem.cs
+++ b/Systems/BossTrackingSystem.cs
@@ -43,6 +43,7 @@ namespace BloodyBoss.Systems
             public bool WasEngaged { get; set; } = false;
             public bool NeedsTeamReferenceSync { get; set; } = false;
             public TeamReference? StoredTeamReference { get; set; } = null;
+            public DateTime? DeathDetectedAt { get; set; } = null;
         }
         
         /// <summary>
@@ -157,12 +158,18 @@ namespace BloodyBoss.Systems
                     var health = entity.Read<ProjectM.Health>();
                     if (health.Value <= 0)
                     {
-                        // Boss is dead, clean up minions first
-                        MinionTrackingSystem.OnBossDeathOrDespawn(entity);
-                        entitiesToRemove.Add(entity);
+                        if (HandleBossDeath(entity, tracked, now))
+                        {
+                            entitiesToRemove.Add(entity);
+                        }
                         continue;
                     }
-                    
+
+                    if (tracked.DeathDetectedAt.HasValue)
+                    {
+                        tracked.DeathDetectedAt = null;
+                    }
+
                     // Calculate current health percentage
                     float currentHealthPercent = (health.Value / health.MaxHealth.Value) * 100f;
                     
@@ -282,8 +289,51 @@ namespace BloodyBoss.Systems
             // Update minion tracking
             MinionTrackingSystem.UpdateMinions();
         }
-        
-        
+
+        /// <summary>
+        /// Called every tick while a tracked boss's health is at or below 0 gives the
+        /// game's own kill confirmation hooks (OnDeathNpc / OnVBloodConsumed in
+        /// BossGameplayEventSystem) time to fire and reset Model.bossSpawn normally 
+        /// those only fire when the death/consume is cleanly attributed to a player
+        /// </summary>
+        /// <returns>True once this boss is finalized and should be removed from tracking</returns>
+        private static bool HandleBossDeath(Entity entity, TrackedBoss tracked, DateTime now)
+        {
+            if (tracked.DeathDetectedAt == null)
+            {
+                tracked.DeathDetectedAt = now;
+                MinionTrackingSystem.OnBossDeathOrDespawn(entity);
+                Plugin.BLogger.Info(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} health reached 0, waiting for kill confwirmation");
+            }
+
+            var timeoutSeconds = PluginConfig.StuckBossRecoveryTimeoutSeconds.Value;
+            if (timeoutSeconds > 0 && now - tracked.DeathDetectedAt.Value < TimeSpan.FromSeconds(timeoutSeconds))
+            {
+                return false;
+            }
+
+            if (tracked.Model.bossSpawn)
+            {
+                Plugin.BLogger.Warning(LogCategory.Boss, $"[BossTracking] Boss {tracked.Model.name} died but no kill was ever confirmed by the game forcing schedule recovery");
+
+                try
+                {
+                    BossGameplayEventSystem.UnregisterBoss(entity);
+                    tracked.Model.BuffKillers();
+                    tracked.Model.SendAnnouncementMessage();
+                }
+                catch (Exception ex)
+                {
+                    Plugin.BLogger.Error(LogCategory.Boss, $"[BossTracking] Error killing stuck boss {tracked.Model.name}: {ex.Message}");
+                    tracked.Model.bossSpawn = false;
+                    tracked.Model.bossEntity = Entity.Null;
+                    Database.saveDatabase();
+                }
+            }
+
+            return true;
+        }
+
         private static void CheckMechanics(Entity entity, TrackedBoss tracked)
         {
             try

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "BloodyBoss",
-  "version_number": "2.1.4",
+  "version_number": "2.1.5",
   "website_url": "https://github.com/oscarpedrero/BloodyBoss",
   "description": "BloodyBoss is an advanced mod for V Rising that allows you to create dynamic VBlood world bosses with intelligent scaling, progressive difficulty, phase announcements, and extensive customization options.",
   "dependencies": [

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -4,7 +4,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "Trodi"
 name = "BloodyBoss"
-versionNumber = "2.1.4"
+versionNumber = "2.1.5"
 description = "Advanced VBlood world boss system with dynamic scaling, boss mechanics, ability discovery, and visual configuration tool. Create epic encounters that adapt to your server population."
 websiteUrl = "https://github.com/oscarpedrero/BloodyBoss"
 containsNsfwContent = false


### PR DESCRIPTION
Currently, when a BloodyBoss spawns via a schedule timer, the system waits indefinitely for a player kill confirmation. If no one engages or kills the boss the entire spawn schedule halts and stops spawning future bosses and this PR is a fix to that